### PR TITLE
Added advanced key selection (all possible values)

### DIFF
--- a/css/muchpc.css
+++ b/css/muchpc.css
@@ -315,6 +315,22 @@
     width: 10mm;
 }
 
+.advanced-selector {
+    margin-top: 25px;
+    font-size: 15pt;
+}
+
+.advanced-selector .warning {
+    color: red;
+    font-style: italic;
+    font-size: 12pt;
+}
+
+.advanced-selector input ,
+.advanced-selector label {
+    vertical-align: middle;
+}
+
 .macro-title {
     max-height: 3em;
     overflow: hidden;

--- a/index.html
+++ b/index.html
@@ -338,6 +338,18 @@
                         </div>
                         <div v-else :class="['fk-space', 'fk-'+key.type]"></div>
                     </div>
+                    <div class="advanced-selector">
+                        <input type="checkbox" id="advanced-toggle" v-model="advanced"><label for="advanced-toggle">Advanced</label>
+                        <div v-show="advanced">
+                            <div class="warning">
+                                [This list includes keys with unknown behaviors! F13 - F24 is pretty safe for extra keys though. :) The ones starting with "KB_" have also mostly worked for me under linux (Xorg) to create more unique keybinding for the i3 window manager with Fn, Fn1 and Pn as modifiers.]
+                            </div>
+                            <select v-model="binding_key">
+                                <option v-for="key in Object.keys(keyLegend)" v-bind:value="key">{{ keyName[key] }}</option>
+                            </select>
+                            <div v-html="keyLegend[binding_key]"></div>
+                        </div>
+                    </div>
                 </div>
                 <div class="uk-margin" uk-overflow-auto>
                     <div v-for="(macro, index) in macros" class="uk-inline">

--- a/js/muchpc.js
+++ b/js/muchpc.js
@@ -843,6 +843,7 @@ var app = new Vue({
         // other
         UIkit: UIkit,
         fileListener: null,
+        advanced: false
     },
     computed: {
         ledClass: function () {


### PR DESCRIPTION
I have kept on experimenting to see how I could expand the functionality of this nice little keyboard and realized that I can go past the macro limit by using keys that are not required by programs normally, so I can catch them with scripts (for example _AutoHotKey_ on Windows or _xmodmap_ / _xbindkeys_ and other utilities under Linux, in my personal setup the i3 configuration) and execute different actions.

(For example I'm using this to be able to type accented characters without having to switch keyboard layouts, as well as desktop / worskpace switching and other custom bindings.)

I thought that this might be useful for others as well, so after repeatedly poking around in the generated JSON files and the browser's console for a while I decided to make some UI for it.